### PR TITLE
Add process.exit to SIGINT handler

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,11 +46,17 @@ GoodKinesis.prototype.init = function(readstream, emitter, callback) {
       function done() {
         squeeze.removeListener('data', update);
 
-        send(assign(self.defaults, {processId: processId, state: 'done'}));
+        send(assign(self.defaults, {processId: processId, state: 'done'}))
+          .then(() => {
+            process.exit(0);
+          })
+          .catch(err => {
+            process.exit(1);
+          });
       }
 
       function send(data) {
-        kinesisClient.putRecordPromised(
+        return kinesisClient.putRecordPromised(
           {
             StreamName: self.streamName,
             PartitionKey: processId,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "good-kinesis",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "main": "index.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fixes #3 

Not sure why this started happening all the sudden, but it is _really_ annoying because you have to `pkill` constantly as you're working

**Testing**
If you'd like to test, you can upload `query` ( or any repo that has this as a dependency ). Run it then try to `Ctrl+C` and verify that you cannont exit the process - create another ssh session and `pkill -9 node` to stop the process. Now upload this module code to the same box. In `/var/cascade/good-kinesis` run `npm link` then in `/var/cascade/sensei3-measurement-query` run `npm link good-kinesis`. This will create a symlink that npm will use instead of the installed version in `node_modules`. At this point you should be able to start and stop the server using `Ctrl-C` as usual.

Don't forget to `npm unlink` after testing. 
